### PR TITLE
Better opcodes indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Output files
 lib/
+
+# IDE folders
+.idea/

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,3 @@
+const start = Date.now();
+
+const iteminfoMock = new Buffer();

--- a/demo.js
+++ b/demo.js
@@ -4,6 +4,8 @@ try {
 	const ci = new CaptureInterface();
 
 	ci.on("message", (type, message) => {
+		console.log(type);
+		console.log(message.parsedIpcData);
 	});
 
 // Get the first device with an IPv4 address.

--- a/demo.js
+++ b/demo.js
@@ -1,13 +1,15 @@
 const { CaptureInterface } = require("./lib/pcap-ffxiv");
 
-const ci = new CaptureInterface();
+try {
+	const ci = new CaptureInterface();
 
-ci.on("message", (type, message) => {
-    console.log(type);
-    console.log(message.parsedIpcData);
-})
+	ci.on("message", (type, message) => {
+	});
 
 // Get the first device with an IPv4 address.
-const device = CaptureInterface.getDevices().find(d => d.addresses.some(a => !a.addr.includes("::")));
+	const device = CaptureInterface.getDevices().find(d => d.addresses.some(a => !a.addr.includes("::")));
 
-ci.on("ready", () => ci.open(device.addresses[0].addr));
+	ci.on("ready", () => ci.open(device.addresses[0].addr));
+} catch (e) {
+	console.error(e);
+}

--- a/src/pcap-ffxiv.ts
+++ b/src/pcap-ffxiv.ts
@@ -27,7 +27,7 @@ export class CaptureInterface extends EventEmitter {
 	private _opcodeLists: OpcodeList[] | undefined;
 	private _constants: { [key in Region]: ConstantsList } | undefined;
 	private _packetDefs: { [key: string]: (buf: Buffer) => any };
-	private _region: Region = "Global";
+	private _region: Region;
 	private _opcodes: Record<number, string> = {};
 
 	constructor(region: Region = "Global") {
@@ -35,7 +35,7 @@ export class CaptureInterface extends EventEmitter {
 
 		this._cap = new Cap();
 		this._buf = Buffer.alloc(65535);
-		this.setRegion(region);
+		this._region = region;
 		this._packetDefs = loadPacketDefs();
 
 		this._loadOpcodes().then(async () => {
@@ -46,6 +46,10 @@ export class CaptureInterface extends EventEmitter {
 
 	setRegion(region: Region) {
 		this._region = region;
+		this.updateOpcodesCache();
+	}
+
+	updateOpcodesCache(): void {
 		const regionOpcodes = this._opcodeLists?.find((ol) => ol.region === this._region);
 		this._opcodes = regionOpcodes?.lists.ServerZoneIpcType.reduce((acc, entry) => {
 			return {
@@ -68,6 +72,7 @@ export class CaptureInterface extends EventEmitter {
 
 	async _loadOpcodes() {
 		this._opcodeLists = await downloadJson("https://raw.githubusercontent.com/karashiiro/FFXIVOpcodes/master/opcodes.min.json");
+		this.updateOpcodesCache();
 	}
 
 	async _loadConstants() {


### PR DESCRIPTION
This builds an index on region change or opcodes loading to avoid using `find` too much, making it faster to retrieve packet name for a given opcode.

I also added a `try...catch` block to demo.js to avoid the capture to stop whenever something is wrong (which happens for now :D)